### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/nl/jworks/markdown_to_asciidoc/Converter.java
+++ b/src/main/java/nl/jworks/markdown_to_asciidoc/Converter.java
@@ -6,7 +6,12 @@ import org.pegdown.ast.RootNode;
 
 import java.io.*;
 
-public class Converter {
+public final class Converter {
+
+    private Converter() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
+
     public static void main(String[] args) throws IOException {
         if (args.length != 1) {
             System.err.println("markdown_to_asciidoc: Please specify a file to convert");

--- a/src/main/java/nl/jworks/markdown_to_asciidoc/html/TableToAsciiDoc.java
+++ b/src/main/java/nl/jworks/markdown_to_asciidoc/html/TableToAsciiDoc.java
@@ -5,7 +5,12 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
-public class TableToAsciiDoc {
+public final class TableToAsciiDoc {
+
+    private TableToAsciiDoc() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
+
     public static String convert(String html) {
         if(!html.startsWith("<table")) {
             throw new IllegalArgumentException("No table found in HTML: " + html);

--- a/src/main/java/nl/jworks/markdown_to_asciidoc/util/Joiner.java
+++ b/src/main/java/nl/jworks/markdown_to_asciidoc/util/Joiner.java
@@ -2,7 +2,11 @@ package nl.jworks.markdown_to_asciidoc.util;
 
 import java.util.List;
 
-public class Joiner {
+public final class Joiner {
+
+    private Joiner() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
 
     public static String join(List<?> list, String delim) {
         int len = list.size();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat